### PR TITLE
Update to "Modern GLSL shaders" and fix alpha values

### DIFF
--- a/materials/burn.fp
+++ b/materials/burn.fp
@@ -1,12 +1,17 @@
+#version 140
 #define speed 1
 #define PI 3.1415926
 
-varying mediump vec4 position;
-varying mediump vec2 var_texcoord0;
+in mediump vec4 position;
+in mediump vec2 var_texcoord0;
+out lowp vec4 color_out;
 
 uniform lowp sampler2D texture_sampler;
-uniform lowp vec4 tint;
-uniform lowp vec4 time;
+uniform fragment_input
+{
+	lowp vec4 tint;
+	lowp vec4 time;
+};
 
 float random(vec2 st) {
 	return fract(sin(dot(st,vec2(94.23,48.127))+14.23)*1124.23);
@@ -58,5 +63,5 @@ void main()
 	vec2 uv = var_texcoord0.xy * res.xy - 0.5;
 	
 	// Pre-multiply alpha since all runtime textures already are
-	gl_FragColor = vec4(burn(texture2D(texture_sampler, var_texcoord0.xy), uv * vec2(res.x / res.y, 1.), time), 1.);
+	color_out = vec4(burn(texture(texture_sampler, var_texcoord0.xy), uv * vec2(res.x / res.y, 1.), time), 1.);
 }

--- a/materials/burn.fp
+++ b/materials/burn.fp
@@ -46,14 +46,14 @@ float displace(vec2 uv, float iTime) {
 	return smoothstep(d,d+.08,distance(uv,d1));
 }
 
-vec3 burn(vec4 col, vec2 uv, float iTime) {
+vec4 burn(vec4 col, vec2 uv, float iTime) {
 	float a = displace(uv, iTime);
 	vec3 b = (1. -a) * vec3(1., .14, .016) * a * 100.;
 	vec3 res = vec3(0);
 	if (col.a > 0) {
 		res = col.rgb * a + b;
 	}
-	return res;
+	return vec4(res, col.w);
 }
 
 void main()
@@ -63,5 +63,5 @@ void main()
 	vec2 uv = var_texcoord0.xy * res.xy - 0.5;
 	
 	// Pre-multiply alpha since all runtime textures already are
-	color_out = vec4(burn(texture(texture_sampler, var_texcoord0.xy), uv * vec2(res.x / res.y, 1.), time), 1.);
+	color_out = burn(texture(texture_sampler, var_texcoord0.xy), uv * vec2(res.x / res.y, 1.), time);
 }


### PR DESCRIPTION
### **User description**
I made these fixes for myself, but thought you might want them back upstream too. Unfortunately they both edit the same line, so they're just a single PR.

I did not test them on this repo, but it shouldn't cause any problems

### 46d6d55029fba4a9c86d845f061fcdf8df8709ab
Just updates burn.fp to ensure it uses the new GLSL pipeline, instead of the old one following [the manual](https://defold.com/manuals/shader/#writing-modern-glsl-shaders). 

I left the precision identifiers, but they could be removed as platforms can set their own precision. So could the variables "tint" and "position" as well as the the "#define pi" because they're not used, but I left them because I figured there was a good reason for them.

### 7a5e3912fed88c4b9775df6e7a2270b8cc049763
This cast:
```glsl
gl_FragColor = vec4(burn(texture2D(texture_sampler, var_texcoord0.xy), uv * vec2(res.x / res.y, 1.), time), 1.);
```
explicitly sets the alpha of the underlying object to `1.` so instead of that, `burn()` now returns a vector4 and just takes the value from the texel.

This makes rounded corners and untrimmed sprites work just like the standard sprite material
|Before | After|
|------|-----|
| <img width="442" height="346" alt="before" src="https://github.com/user-attachments/assets/71f0ae82-ba5f-4bba-b2df-2dedbc0e110f" /> | <img width="395" height="220" alt="after" src="https://github.com/user-attachments/assets/24b0fe41-e83c-471e-bd8e-71bab7435572" /> |


___

### **PR Type**
Enhancement


___

### **Description**
- Update GLSL shader to modern version 140 pipeline

- Fix alpha channel handling for proper transparency

- Replace deprecated varying/gl_FragColor with modern syntax

- Preserve original texture alpha instead of forcing opaque


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old GLSL Pipeline"] --> B["Modern GLSL v140"]
  C["Alpha forced to 1.0"] --> D["Preserve texture alpha"]
  B --> E["Updated shader syntax"]
  D --> F["Proper transparency support"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>burn.fp</strong><dd><code>Modernize GLSL shader and fix alpha handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

materials/burn.fp

<ul><li>Added <code>#version 140</code> directive for modern GLSL<br> <li> Replaced <code>varying</code> with <code>in</code> and added <code>out color_out</code><br> <li> Updated uniform block syntax with <code>fragment_input</code><br> <li> Modified <code>burn()</code> function to return <code>vec4</code> with preserved alpha<br> <li> Replaced <code>gl_FragColor</code> with <code>color_out</code> and <code>texture2D</code> with <code>texture</code></ul>


</details>


  </td>
  <td><a href="https://github.com/appsoluut/defold-balatro-card-burn-effect/pull/1/files#diff-4c1e47d2120565f48dd752971acd346d4f7d936c21d6b392f29ef78ac906ccbc">+12/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

